### PR TITLE
Show the navigation on top of content for smaller devices

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -25,3 +25,6 @@ indent_size = 4
 
 [Makefile]
 indent_style = tab
+
+[*.md]
+trim_trailing_whitespace = false

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -3,10 +3,10 @@
 
 <div class="container content">
 	<div class="row">
-		<div class="col-xs-3">
+		<div class="col-md-3">
 			{{ partial "menu" . }}
 		</div>
-		<div class="col-xs-9">
+		<div class="col-md-9">
 			{{ range where .Site.Pages "Type" "page" }}
 				{{ .Content }}
 			{{ end }}


### PR DESCRIPTION
See screenshosts in the PR for theme.
https://github.com/go-gitea/theme/pull/26