### PR TITLE
Add 'usage' section with explanation of 'dump' command

### DIFF
--- a/content/doc/usage.en-us.md
+++ b/content/doc/usage.en-us.md
@@ -1,0 +1,13 @@
+---
+date: "2016-12-27T16:00:00+02:00"
+title: "Usage"
+slug: "usage"
+weight: 35
+toc: false
+draft: false
+menu:
+  sidebar:
+    name: "Usage"
+    weight: 35
+    identifier: "usage"
+---

--- a/content/doc/usage/backup-and-restore.en-us.md
+++ b/content/doc/usage/backup-and-restore.en-us.md
@@ -1,0 +1,49 @@
+---
+date: "2016-12-27T16:00:00+02:00"
+title: "Usage: Backup and Restore"
+slug: "backup-and-restore"
+weight: 11
+toc: true
+draft: false
+menu:
+  sidebar:
+    parent: "usage"
+    name: "Backup and Restore"
+    weight: 11
+    identifier: "backup-and-restore"
+---
+
+# Backup and Restore
+
+Gitea currently has a `dump` command that will save your installation to a zip
+file. There will be a `restore` command implemented at some point in the future.
+You will be able to use this to back up your installation, as well as make
+migrating servers easier.
+
+## Backup Command (`dump`)
+
+First, switch to the user running gitea: `su git` (or whatever user you are
+  using). Run `./gitea dump` in the gitea installation directory. You should
+  see some output similar to this:
+
+```
+2016/12/27 22:32:09 Creating tmp work dir: /tmp/gitea-dump-417443001
+2016/12/27 22:32:09 Dumping local repositories.../home/git/gitea-repositories
+2016/12/27 22:32:22 Dumping database...
+2016/12/27 22:32:22 Packing dump files...
+2016/12/27 22:32:34 Removing tmp work dir: /tmp/gitea-dump-417443001
+2016/12/27 22:32:34 Finish dumping in file gitea-dump-1482906742.zip
+```
+
+Inside the `gitea-dump-1482906742.zip` file, you will find the following:
+
+* `custom/conf/app.ini` - This is your server config.
+* `gitea-db.sql` - the mysql dump (TODO add info for other databases)
+* `gitea-repo.zip` - This zip will be a complete copy of your repo folder.
+   See Config -> repository -> `ROOT` for the location.
+* `log/` - this will contain various logs. You don't need these if you are doing
+   a migration.
+
+## Restore Command (`restore`)
+
+WIP: Does not exist yet.


### PR DESCRIPTION
As per go-gitea/gitea#448, sending a PR that adds a new 'Usage' section to the docs and documents the behavior of the `dump` command.

Please let me know what you think of the phrasing and structure.

Looking forward, it would be nice to have explanations of all the commands added to these docs. Right now this information is only present in the CLI help:

```
     web      Start Gitea web server
     serv     This command should only be called by SSH shell
     update   This command should only be called by Git hook
     dump     Dump Gitea files and database
     cert     Generate self-signed certificate
     admin    Preform admin operations on command line
     help, h  Shows a list of commands or help for one command
```

IMO, `web` `cert` and `admin` would be the most useful.