### PR TITLE
Fix supported Gogs version to existing tag 0.9.97

### DIFF
--- a/content/doc/upgrade/from-gogs.en-us.md
+++ b/content/doc/upgrade/from-gogs.en-us.md
@@ -15,7 +15,10 @@ menu:
 
 # Upgrade from Gogs
 
-If you are running Gogs which version is below 0.9.99, you can upgrade Gogs to Gitea smoothly. There are some steps to do below. Make sure to complete as the gitea user in ~:
+Gogs versions up to 0.9.97 can be smootlhy upgraded to Gitea.
+
+There are some steps to do so below.
+Make sure to complete them as the gitea user in ~:
 
 * Stop Gogs
 * cd ~

--- a/content/doc/upgrade/from-gogs.zh-cn.md
+++ b/content/doc/upgrade/from-gogs.zh-cn.md
@@ -15,7 +15,7 @@ menu:
 
 # 从 Gogs 升级
 
-如果你正在运行Gogs 0.9.99以下版本，你可以平滑的升级到Gitea。该升级需要如下的步骤：
+如果你正在运行Gogs 0.9.97以下版本，你可以平滑的升级到Gitea。该升级需要如下的步骤：
 
 * 停止 Gogs 的运行
 * 拷贝 Gogs 的配置文件 `custom/conf/app.ini` 到 Gitea 的相应位置。

--- a/content/doc/upgrade/from-gogs.zh-tw.md
+++ b/content/doc/upgrade/from-gogs.zh-tw.md
@@ -15,7 +15,7 @@ menu:
 
 # 從 Gogs 升級
 
-假如您正在運行 Gogs 0.9.99 以下版本，你可以很平順的升級到 Gitea，請參考底下升級步驟：
+假如您正在運行 Gogs 0.9.97 以下版本，你可以很平順的升級到 Gitea，請參考底下升級步驟：
 
 * 停止 Gogs 服務。
 * 複製 Gogs 設定檔 `custom/conf/app.ini` 到 Gitea 相對應位置。


### PR DESCRIPTION
0.9.99 tag does not exist in Gogs.
0.9.97 is the last one before the fork, followed by 0.9.113 which
is not yet tested for upgrade (see #57)