### PR TITLE
Add 'Help' menu at left menu bar for Chinese language

### DIFF
--- a/content/doc/advanced/hacking-on-gitea.zh-cn.md
+++ b/content/doc/advanced/hacking-on-gitea.zh-cn.md
@@ -15,7 +15,7 @@ menu:
 
 # Hacking on Gitea
 
-首先你需要一些运行环境，这和 [从源代码安装](/zh-cn/install-from-source) 相同，如果你还没有设置好，可以先阅读那个章节。
+首先你需要一些运行环境，这和 [从源代码安装]({{< relref "from-source.zh-cn.md" >}}) 相同，如果你还没有设置好，可以先阅读那个章节。
 
 如果你想为 Gitea 贡献代码，你需要 Fork 这个项目并且以 `master` 为开发分支。Gitea使用Govendor来管理依赖，因此所有依赖项都被工具自动copy在vendor子目录下。用下面的命令来下载源码：
 

--- a/content/doc/help.zh-cn.md
+++ b/content/doc/help.zh-cn.md
@@ -1,0 +1,13 @@
+---
+date: "2017-01-20T15:00:00+08:00"
+title: "帮助"
+slug: "help"
+weight: 50
+toc: false
+draft: false
+menu:
+  sidebar:
+    name: "帮助"
+    weight: 50
+    identifier: "help"
+---

--- a/content/doc/help/seek-help.zh-cn.md
+++ b/content/doc/help/seek-help.zh-cn.md
@@ -1,0 +1,23 @@
+---
+date: "2017-01-20T15:00:00+08:00"
+title: "需要帮助"
+slug: "seek-help"
+weight: 10
+toc: true
+draft: false
+menu:
+  sidebar:
+    parent: "help"
+    name: "需要帮助"
+    weight: 20
+    identifier: "seek-help"
+---
+
+## 需要帮助?
+
+如果您在使用或者开发过程中遇到问题，请到以下渠道咨询：
+
+- 到[Github issue](https://github.com/go-gitea/gitea/issues)提问(因为项目维护人员来自世界各地，为保证沟通顺畅，请使用英文提问)
+- 中文问题到[gocn.io](https://gocn.io/topic/Gitea)提问
+- 访问 [Gitter channel - 英文](https://gitter.im/go-gitea/gitea/)
+- 加入 QQ群 328432459 获得进一步的支持

--- a/content/doc/installation/from-binary.zh-cn.md
+++ b/content/doc/installation/from-binary.zh-cn.md
@@ -32,4 +32,4 @@ chmod +x gitea
 
 ## 需要帮助?
 
-如果从本页中没有找到你需要的内容，请访问 [Gitter channel - 英文](https://gitter.im/go-gitea/gitea/) 或加入 QQ群 328432459 获得进一步的支持。
+如果从本页中没有找到你需要的内容，请访问 [帮助页面]({{< relref "seek-help.zh-cn.md" >}})

--- a/content/doc/installation/from-package.zh-cn.md
+++ b/content/doc/installation/from-package.zh-cn.md
@@ -34,4 +34,4 @@ brew install gitea
 
 ## 需要帮助?
 
-如果从本页中没有找到你需要的内容，请访问 [Gitter channel - 英文](https://gitter.im/go-gitea/gitea/) 或加入 QQ群 328432459 获得进一步的支持。
+如果从本页中没有找到你需要的内容，请访问 [帮助页面]({{< relref "seek-help.zh-cn.md" >}})

--- a/content/doc/installation/from-source.zh-cn.md
+++ b/content/doc/installation/from-source.zh-cn.md
@@ -81,4 +81,4 @@ go build
 
 ## 需要帮助?
 
-如果从本页中没有找到你需要的内容，请访问 [Gitter channel - 英文](https://gitter.im/go-gitea/gitea/) 或加入 QQ群 328432459 获得进一步的支持。
+如果从本页中没有找到你需要的内容，请访问 [帮助页面]({{< relref "seek-help.zh-cn.md" >}})

--- a/content/doc/installation/with-docker.zh-cn.md
+++ b/content/doc/installation/with-docker.zh-cn.md
@@ -39,4 +39,4 @@ docker run -d --name=gitea -p 10022:22 -p 10080:3000 -v /var/lib/gitea:/data git
 
 ## 需要帮助?
 
-如果从本页中没有找到你需要的内容，请访问 [Gitter channel - 英文](https://gitter.im/go-gitea/gitea/) 或加入 QQ群 328432459 获得进一步的支持。
+如果从本页中没有找到你需要的内容，请访问 [帮助页面]({{< relref "seek-help.zh-cn.md" >}})

--- a/content/page/index.zh-cn.md
+++ b/content/page/index.zh-cn.md
@@ -69,3 +69,7 @@ Gitea的首要目标是创建一个极易安装，运行非常快速，安装和
 ## 软件及服务支持
 
 - [Drone](https://github.com/drone/drone) (CI)
+
+## 需要帮助?
+
+如果从本页中没有找到你需要的内容，请访问 [帮助页面]({{< relref "seek-help.zh-cn.md" >}})


### PR DESCRIPTION
1. Add help menu with help page at left menu bar, because the help section appear at the bottom in many pages and it misses the gocn.io for Chinese users, this makes many Chinese users ask issues in github by Chinese. This changes was made to avoid such situation, and guide Chinese users ask Chinese issue in gocn.io.
2. Add github issue and gocn.io channel in help page.
3. Change all installation page with help section to point to the new help page.

All the changes are tested and expected in locally.
ps, i also make this enhancement for English language, i would post a new PR if you think this is ok for you.