### PR TITLE
Updated from-binary example to gitea version 1.0.1

### DIFF
--- a/content/doc/installation/from-binary.en-us.md
+++ b/content/doc/installation/from-binary.en-us.md
@@ -18,7 +18,7 @@ menu:
 All downloads come with SQLite, MySQL and PostgreSQL support, and are built with embedded assets. Keep in mind that this can be different for older releases. The installation based on our binaries is quite simple, just choose the file matching your platform from the [downloads page](https://dl.gitea.io/gitea), copy the URL and replace the URL within the commands below:
 
 ```
-wget -O gitea https://dl.gitea.io/gitea/1.0.0/gitea-1.0.0-linux-amd64
+wget -O gitea https://dl.gitea.io/gitea/1.0.1/gitea-1.0.1-linux-amd64
 chmod +x gitea
 ```
 


### PR DESCRIPTION
I updated the string for en-us installation from binary due to possible missunderstandings.

I recently wanted to use gitea, so is just looked in the docs. Using debian jessi 64-bit I immediately saw the install instrcution:

> wget -O gitea https://dl.gitea.io/gitea/1.0.0/gitea-1.0.0-linux-amd64

> chmod +x gitea

Installing from this binary, I had a version with bugs which already has been fixed in 1.0.1 (like users can't be deleted). After I opend a issue @lunny told me that this issue has been fixed on 1.0.1.

Even thoug you can replace the string, users who skip reading the first few sentences might skip the recent stable version and install an older version.
