### PR TITLE
from-source: add info on how to install go-bindata

### DIFF
--- a/content/doc/installation/from-source.en-us.md
+++ b/content/doc/installation/from-source.en-us.md
@@ -42,6 +42,12 @@ git tag -l
 git checkout v1.0.0
 ```
 
+If you want to build a `bindata` build, make sure to install the `go-bindata` dependency:
+
+```
+go get -u github.com/jteeuwen/go-bindata/...
+```
+
 ## Build
 
 Since we already bundle all required libraries to build Gitea you can continue with the build process itself. We provide various [make tasks](https://github.com/go-gitea/gitea/blob/master/Makefile) to keep the build process as simple as possible. <a href='{{< relref "doc/advanced/make.en-us.md" >}}'>See here how to get Make</a>. Depending on your requirements you possibly want to add various build tags, you can choose between these tags:


### PR DESCRIPTION
I've been mislead to installing `go-bindata` from a system repository which lead to failing builds, so I think it's best to include the right way to install it here.