### PR TITLE
Fix init scripts link

### DIFF
--- a/content/doc/upgrade/from-gogs.en-us.md
+++ b/content/doc/upgrade/from-gogs.en-us.md
@@ -67,7 +67,7 @@ ROOT_PATH = /home/:USER/gitea/log
 
 ### Add Gitea to startup on Unix
 
-Update the appropriate file from [gitea/scripts](https://github.com/go-gitea/gitea/tree/master/scripts) with the right environment variables.
+Update the appropriate file from [gitea/contrib](https://github.com/go-gitea/gitea/tree/master/contrib) with the right environment variables.
 
 For distro's with systemd:
 


### PR DESCRIPTION
The scripts have been moved to `contrib/`.

There's also a gogs migrate script in `contrib/` that mysteriously isn't mentioned anywhere in the docs, but I don't know if it's usable.